### PR TITLE
Add zedpm plugin go test

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/hashicorp/go-hclog"
 	"github.com/spf13/cobra"
@@ -101,6 +103,8 @@ func Execute() int {
 	e := master.NewExecutor(logger, m)
 
 	ctx := context.Background()
+	ctx, cancel := signal.NotifyContext(ctx, syscall.SIGINT, syscall.SIGPIPE, syscall.SIGTERM, syscall.SIGQUIT, syscall.SIGHUP)
+	defer cancel()
 	ctx = hclog.WithContext(ctx, logger)
 	goals, err := e.PotentialGoalsPhasesAndTasks(ctx)
 	if err != nil {

--- a/pkg/log/interface.go
+++ b/pkg/log/interface.go
@@ -1,5 +1,16 @@
 package log
 
+import "io"
+
+type Level int
+
+const (
+	LevelDebug Level = iota
+	LevelInfo
+	LevelWarn
+	LevelError
+)
+
 // Interface is the logging interface that is provided to both the plugin
 // logging system and the master logging system.
 type Interface interface {
@@ -14,4 +25,6 @@ type Interface interface {
 	StartAction(key, desc string, flags ...ActionFlag)
 	TickAction(key string)
 	MarkAction(key string, outcome Outcome)
+
+	Output(level Level) io.Writer
 }

--- a/pkg/log/logger.go
+++ b/pkg/log/logger.go
@@ -1,6 +1,7 @@
 package log
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 
@@ -139,7 +140,10 @@ type logWriter struct {
 
 func (w *logWriter) Write(p []byte) (int, error) {
 	n := len(p)
-	w.logFunc(string(p))
+	lines := bytes.Split(p, []byte{'\n'})
+	for _, line := range lines {
+		w.logFunc(string(line))
+	}
 	return n, nil
 }
 

--- a/pkg/log/logger.go
+++ b/pkg/log/logger.go
@@ -2,6 +2,7 @@ package log
 
 import (
 	"fmt"
+	"io"
 
 	"github.com/zostay/go-std/slices"
 )
@@ -130,6 +131,35 @@ func (l *Logger) Warn(fmt string, args ...any) {
 func (l *Logger) Debug(fmt string, args ...any) {
 	args = l.allFields(args)
 	l.log.Debug(Smprintf(fmt, args...), args...)
+}
+
+type logWriter struct {
+	logFunc func(string, ...any)
+}
+
+func (w *logWriter) Write(p []byte) (int, error) {
+	n := len(p)
+	w.logFunc(string(p))
+	return n, nil
+}
+
+// Output returns an io.Writer that can be used to write to the given log level.
+func (l *Logger) Output(level Level) io.Writer {
+	var logFunc func(string, ...any)
+	switch level {
+	case LevelDebug:
+		logFunc = l.Debug
+	case LevelInfo:
+		logFunc = l.Info
+	case LevelWarn:
+		logFunc = l.Warn
+	case LevelError:
+		logFunc = l.Error
+	default:
+		panic("unknown level")
+	}
+
+	return &logWriter{logFunc}
 }
 
 // With returns a new logger with the given args included with every log sent.

--- a/plugin-go/goImpl/doc.go
+++ b/plugin-go/goImpl/doc.go
@@ -1,0 +1,2 @@
+// Package goImpl provides the implementaiton of the zedpm-plugin-go.
+package goImpl

--- a/plugin-go/goImpl/go.go
+++ b/plugin-go/goImpl/go.go
@@ -1,0 +1,1 @@
+package goImpl

--- a/plugin-go/goImpl/plugin.go
+++ b/plugin-go/goImpl/plugin.go
@@ -1,0 +1,49 @@
+package goImpl
+
+import (
+	"context"
+
+	"github.com/zostay/zedpm/pkg/goals"
+	"github.com/zostay/zedpm/plugin"
+)
+
+// Verify that Plugin implements plugin.Interface
+var _ plugin.Interface = &Plugin{}
+
+// Plugin implements the plugin.Interface for performing tasks related to go.
+type Plugin struct{}
+
+// Implements provides task descriptions for /test/run/go tasks.
+func (p *Plugin) Implements(ctx context.Context) ([]plugin.TaskDescription, error) {
+	test := goals.DescribeTest()
+	return []plugin.TaskDescription{
+		test.Task("run", "go", "Run the go test command."),
+	}, nil
+}
+
+// Goal returns plugin.ErrUnsupportedGoal.
+func (p *Plugin) Goal(ctx context.Context, name string) (plugin.GoalDescription, error) {
+	return nil, plugin.ErrUnsupportedGoal
+}
+
+// Prepare returns plugin.Task implementations for the implemented tasks.
+func (p *Plugin) Prepare(
+	_ context.Context,
+	task string,
+) (plugin.Task, error) {
+	switch task {
+	case "/test/run/go":
+		return &TestRunTask{}, nil
+	}
+	return nil, plugin.ErrUnsupportedTask
+}
+
+// Cancel is a no-op.
+func (p *Plugin) Cancel(ctx context.Context, task plugin.Task) error {
+	return nil
+}
+
+// Complete is a no-op.
+func (p *Plugin) Complete(ctx context.Context, task plugin.Task) error {
+	return nil
+}

--- a/plugin-go/goImpl/test-run.go
+++ b/plugin-go/goImpl/test-run.go
@@ -1,0 +1,41 @@
+package goImpl
+
+import (
+	"context"
+	"os/exec"
+
+	"github.com/zostay/zedpm/pkg/log"
+	"github.com/zostay/zedpm/plugin"
+)
+
+type TestRunTask struct {
+	plugin.TaskBoilerplate
+}
+
+func (s *TestRunTask) RunTests(ctx context.Context) error {
+	logger := plugin.Logger(ctx,
+		"operation", "RunTests",
+		"task", "/test/run/go",
+	)
+	logger.Info("Running go test -v ./...")
+
+	cmd := exec.CommandContext(ctx, "go", "test", "-v", "./...")
+	cmd.Stdout = logger.Output(log.LevelInfo)
+	cmd.Stderr = logger.Output(log.LevelError)
+	err := cmd.Run()
+
+	plugin.Logger(ctx,
+		"exitcode", cmd.ProcessState.ExitCode(),
+	).Info("Exited go test -v ./...")
+
+	return err
+}
+
+func (s *TestRunTask) Run(context.Context) (plugin.Operations, error) {
+	return plugin.Operations{
+		{
+			Order:  50,
+			Action: plugin.OperationFunc(s.RunTests),
+		},
+	}, nil
+}

--- a/plugin-go/zedpm-plugin-go.go
+++ b/plugin-go/zedpm-plugin-go.go
@@ -1,0 +1,10 @@
+package main
+
+import (
+	"github.com/zostay/zedpm/plugin-go/goImpl"
+	"github.com/zostay/zedpm/plugin/metal"
+)
+
+func main() {
+	metal.RunPlugin(&goImpl.Plugin{})
+}

--- a/plugin/master/exec.go
+++ b/plugin/master/exec.go
@@ -30,12 +30,14 @@ import (
 type InterfaceExecutor struct {
 	m      *Interface
 	logger hclog.Logger
-	taskCh chan string
+
+	// TODO Why did I add this? Remove it?
+	// taskCh chan string
 }
 
 // NewExecutor creates a new InterfaceExecutor paired with the given Interface.
 func NewExecutor(logger hclog.Logger, m *Interface) *InterfaceExecutor {
-	return &InterfaceExecutor{m, logger, make(chan string)}
+	return &InterfaceExecutor{m, logger} // , make(chan string)}
 }
 
 // SetTargetName is used to update the target name to use when configuring the

--- a/plugin/master/op-exec.go
+++ b/plugin/master/op-exec.go
@@ -51,14 +51,14 @@ func (s *SimpleExecutor) Execute(
 			)
 			ctx = hclog.WithContext(ctx, logger)
 
-			s.exec.taskCh <- taskName
+			// s.exec.taskCh <- taskName
 			task, err := s.exec.prepare(ctx, taskName)
 			if err != nil {
 				return format.WrapErr(err, "failed to prepare task %q", taskName)
 			}
 
 			err = s.run(task, ctx)
-			s.exec.taskCh <- ""
+			// s.exec.taskCh <- ""
 			if err != nil {
 				return format.WrapErr(err, "failed to execute operation %s", s.stageName)
 			}

--- a/plugin/metal/load.go
+++ b/plugin/metal/load.go
@@ -12,9 +12,6 @@ import (
 	"github.com/zostay/zedpm/config"
 	"github.com/zostay/zedpm/format"
 	"github.com/zostay/zedpm/plugin"
-	"github.com/zostay/zedpm/plugin-changelog/changelogImpl"
-	"github.com/zostay/zedpm/plugin-git/gitImpl"
-	"github.com/zostay/zedpm/plugin-github/githubImpl"
 )
 
 // runPluginServerLocally is a variable that can be configured to replace or add
@@ -26,6 +23,7 @@ var runPluginServerLocally = map[string]plugin.Interface{
 	// "changelog": &changelogImpl.Plugin{},
 	// "github": &githubImpl.Plugin{},
 	// "git": &gitImpl.Plugin{},
+	// "go": &goImpl.Plugin{},
 }
 
 // Clients represents a list of Hashicorp plugins we are running to implement

--- a/zedpm.conf
+++ b/zedpm.conf
@@ -36,6 +36,9 @@ plugin changelog  "go run github.com/zostay/zedpm/plugin-changelog" {
 plugin git "go run github.com/zostay/zedpm/plugin-git" {
 }
 
+plugin go "go run github.com/zostay/zedpm/plugin-go" {
+}
+
 plugin github "go run github.com/zostay/zedpm/plugin-github" {
 }
 


### PR DESCRIPTION
Adding a `zedpm run test` command that executes `go test -v ./...`

More configurability will be added later.